### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br/>
 
 <div align=center>
-<a href="https://pub.dartlang.org/packages/zerker" target="_blank"><img src="https://img.shields.io/pub/v/zerker.svg" alt="pub package" /></a>
+<a href="https://pub.dev/packages/zerker" target="_blank"><img src="https://img.shields.io/pub/v/zerker.svg" alt="pub package" /></a>
 <a href="https://flutter.dev/" target="_blank"><img src="https://img.shields.io/badge/Made%20with-Flutter-5fc9f8.svg" alt="Made-with-Flutter" /></a>
 <a href="https://dart.dev/" target="_blank"><img src="https://img.shields.io/badge/Made%20with-Dart-13589c.svg" alt="Made-with-Dart" /></a>
 </div>


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.